### PR TITLE
Use 2024.2 release, no longer request filesystem=home

### DIFF
--- a/io.github.NickKarpowicz.LightwaveExplorer.json
+++ b/io.github.NickKarpowicz.LightwaveExplorer.json
@@ -1,7 +1,7 @@
 {
     "id": "io.github.NickKarpowicz.LightwaveExplorer",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "44",
+    "runtime-version": "45",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions":[
         "org.freedesktop.Sdk.Extension.llvm15"],
@@ -10,8 +10,7 @@
         "--share=ipc",
         "--device=dri",
         "--socket=wayland",
-        "--socket=fallback-x11",
-        "--filesystem=home"
+        "--socket=fallback-x11"
     ],
     "cleanup": [
         "/include",
@@ -62,11 +61,11 @@
                 "prepend-ld-library-path": "/usr/lib/sdk/llvm15/lib"
                 },
             "build-commands": [
-                    "chmod +x l_BaseKit_p_2023.2.0.49397_offline.sh",
-                    "./l_BaseKit_p_2023.2.0.49397_offline.sh -x -f webimage_extracted",
-                    "rm l_BaseKit_p_2023.2.0.49397_offline.sh",
-                    "webimage_extracted/l_BaseKit_p_2023.2.0.49397_offline/bootstrapper -s --action=install --components=intel.oneapi.lin.mkl.devel:intel.oneapi.lin.tbb.devel:intel.oneapi.lin.dpcpp-cpp-compiler --install-dir=/app/opt/intel/oneapi --eula=accept",
-                    "rm -rf /app/opt/intel/oneapi/compiler/latest/linux/lib/oclfpga/host/linux64/bin/perl/lib",
+                    "chmod +x l_BaseKit_p_2024.0.1.46_offline.sh",
+                    "./l_BaseKit_p_2024.0.1.46_offline.sh -x -f webimage_extracted",
+                    "rm l_BaseKit_p_2024.0.1.46_offline.sh",
+                    "webimage_extracted/l_BaseKit_p_2024.0.1.46_offline/bootstrapper -s --action=install --components=intel.oneapi.lin.mkl.devel:intel.oneapi.lin.tbb.devel:intel.oneapi.lin.dpcpp-cpp-compiler --install-dir=/app/opt/intel/oneapi --eula=accept",
+                    "rm -rf /app/opt/intel/oneapi/compiler/latest/opt/oclfpga/host/linux64/bin/perl/lib",
                     "mkdir /app/lib",
                     "cp -a /app/opt/intel/oneapi/tbb/latest/lib/intel64/gcc4.8/libtbb.so* /app/lib/",
                     "cp -a /app/opt/intel/oneapi/tbb/latest/lib/intel64/gcc4.8/libtbbmalloc.so* /app/lib/"
@@ -74,8 +73,8 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/992857b9-624c-45de-9701-f6445d845359/l_BaseKit_p_2023.2.0.49397_offline.sh",
-                    "sha256": "3dd04d2cc9ba2a8785580ba09068dbaf9aff9aa930b5fa7f10688210ea9be4a0"
+                    "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/163da6e4-56eb-4948-aba3-debcec61c064/l_BaseKit_p_2024.0.1.46_offline.sh",
+                    "sha256": "2f60c99098fe81c7aaab3d92cd0bede777567ac8946c8b5cc74876b4e573e1ea"
         
                 }
             ],
@@ -121,6 +120,18 @@
                 ]
         },
         {
+            "name": "miniz",
+            "buildsystem": "cmake-ninja",
+            "sources":[
+                {
+                    "type": "git",
+                    "url": "https://github.com/richgel999/miniz",
+                    "tag": "3.0.2",
+                    "commit": "293d4db1b7d0ffee9756d035b9ac6f7431ef8492"
+                }
+            ]
+        },
+        {
             "name": "cuda",
             "buildsystem": "simple",
             "build-commands":[
@@ -152,8 +163,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/NickKarpowicz/LightwaveExplorer",
-                    "tag": "2023.09.01",
-                    "commit": "b0634b0ceff6b277dfbb6dc4f529a126b23bc292"
+                    "tag": "2024.2",
+                    "commit": "8b613cf54e09a7bd5fbc856e6f40f0ef0e16a652"
                 }
             ]
         } 


### PR DESCRIPTION
Use the latest tagged release, which changes file io such that it fully works with portals, no longer requiring home folder access.