### PR TITLE
Update to 2024.4.2

### DIFF
--- a/io.github.NickKarpowicz.LightwaveExplorer.json
+++ b/io.github.NickKarpowicz.LightwaveExplorer.json
@@ -131,8 +131,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/NickKarpowicz/LightwaveExplorer",
-                    "tag": "2024.4.1",
-                    "commit": "7185d4dc4dd2e51466db0818bc087e2ce5d0aff6"
+                    "tag": "2024.4.2",
+                    "commit": "02bb366077d2161e69a13bf4991d946fbd7d8324"
                 }
             ]
         } 


### PR DESCRIPTION
Fix regression introduced in 2024.4.0: factor of two that was corrected then was actually already correct.

Fix behavior of loading saved simulation results with a FROG (or other type) of measured pulse; now the pulse stored in the result will be loaded and the correct option on the pull-down menu selected.