### PR TITLE
Update to 2025.1

### DIFF
--- a/io.github.NickKarpowicz.LightwaveExplorer.json
+++ b/io.github.NickKarpowicz.LightwaveExplorer.json
@@ -131,8 +131,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/NickKarpowicz/LightwaveExplorer",
-                    "tag": "v2025.0.1",
-                    "commit": "a5b56c595f594a1627daf9451b206d9e5651ed29"
+                    "tag": "v2025.1",
+                    "commit": "a4c6c696e3f813b897550e34e8c0c715f98df619"
                 }
             ]
         } 


### PR DESCRIPTION
2025.1 changes:
- Fixed a bug introduced in 2025.0 where on CUDA the plasma would not affect fields in the y-direction
- Fixed a bug where cancelling a batch job caused the subsequent batch to cancel itself
- Axes and scales are now shown on the space and momentum images, and they're also saved when an SVG is produced.
- Plot font size scaling works better with high-DPI displays
- Refactored device structures to more efficiently and consistently allocate memory