### PR TITLE
Update to 2025.2

### DIFF
--- a/io.github.NickKarpowicz.LightwaveExplorer.json
+++ b/io.github.NickKarpowicz.LightwaveExplorer.json
@@ -131,8 +131,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/NickKarpowicz/LightwaveExplorer",
-                    "tag": "v2025.2.1.1",
-                    "commit": "b8b765910862693b2cc9a3c1538250cd46b70da5"
+                    "tag": "v2025.2.2",
+                    "commit": "6ff5340070a92a21fda28e34b4e554a89e9d216f"
                 }
             ]
         } 

--- a/io.github.NickKarpowicz.LightwaveExplorer.json
+++ b/io.github.NickKarpowicz.LightwaveExplorer.json
@@ -131,8 +131,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/NickKarpowicz/LightwaveExplorer",
-                    "tag": "v2025.2",
-                    "commit": "8611d87df476728961a271779aec118530667c0e"
+                    "tag": "v2025.2.1",
+                    "commit": "528eb646e127a8bc70b549a2365149034dcb23bd"
                 }
             ]
         } 

--- a/io.github.NickKarpowicz.LightwaveExplorer.json
+++ b/io.github.NickKarpowicz.LightwaveExplorer.json
@@ -131,8 +131,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/NickKarpowicz/LightwaveExplorer",
-                    "tag": "v2025.1",
-                    "commit": "a4c6c696e3f813b897550e34e8c0c715f98df619"
+                    "tag": "v2025.2",
+                    "commit": "8611d87df476728961a271779aec118530667c0e"
                 }
             ]
         } 

--- a/io.github.NickKarpowicz.LightwaveExplorer.json
+++ b/io.github.NickKarpowicz.LightwaveExplorer.json
@@ -131,8 +131,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/NickKarpowicz/LightwaveExplorer",
-                    "tag": "v2025.2.1",
-                    "commit": "528eb646e127a8bc70b549a2365149034dcb23bd"
+                    "tag": "v2025.2.1.1",
+                    "commit": "b8b765910862693b2cc9a3c1538250cd46b70da5"
                 }
             ]
         } 


### PR DESCRIPTION
- Added new beam visualization mode, where you can make color images of the light field that results from the simulation
- Add new controls for the appearance of plots, which you can access by clicking the ↔️ button on the bottom of the window.
- Fixed a bug where a FROG file loaded for pulse 2 wouldn't be used.
- Fixed a bug where very large grids whose dimensions were divisible by 4 but not by 8 would look weird.